### PR TITLE
Move hide function for create task to its view

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,28 +1,20 @@
-// https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
-document.addEventListener("DOMContentLoaded", () => {
-  console.log("activity_logger JS imported successfully!");
+document.addEventListener('DOMContentLoaded', () => {
+	console.log('activity_logger JS imported successfully!');
 });
 
-const repeat = document.getElementById('repeat');
-const days = document.getElementById('days');
-const specificDay = document.getElementById('specific-day');
-
 function selectRecurrence() {
+	const repeat = document.getElementById('repeat');
+	const days = document.getElementById('days');
+	const specificDay = document.getElementById('specific-day');
 
-
-  if (repeat.value === 'weekly') {
-    days.style.display = 'block';
-    specificDay.style.display = 'none';
-
-  } else if (repeat.value === 'once') {
-    specificDay.style.display = 'block';
-    days.style.display = 'none';
-  }
-
+	if (repeat.value === 'weekly') {
+		days.style.display = 'block';
+		specificDay.style.display = 'none';
+	} else if (repeat.value === 'once') {
+		specificDay.style.display = 'block';
+		days.style.display = 'none';
+	}
 }
 //
-window.onload = function () {
-  specificDay.style.display = 'none';
-  days.style.display = 'none';
 
-}
+

--- a/routes/activity.routes.js
+++ b/routes/activity.routes.js
@@ -178,4 +178,19 @@ router.get('/schedule', async (req, res, next) => {
 	}
 });
 
+router.post('/schedule', isLoggedIn, async (req, res, next) => {
+
+	const { _id } = req.body;
+
+	try {
+		const activity = await Activity.findByIdAndUpdate(_id, { isDone: true }, { new: true });
+		console.log(activity);
+	} catch (error) {
+		console.error(error);
+		next(error);
+		res.status(500).send('Server error');
+	}
+
+});
+
 module.exports = router;

--- a/views/create-activity.hbs
+++ b/views/create-activity.hbs
@@ -63,6 +63,9 @@
 	<script src='/js/script.js'></script>
 
 	<script>
+		window.onload = function () { const repeat = document.getElementById('repeat'); const days =
+		document.getElementById('days'); const specificDay = document.getElementById('specific-day');
+		specificDay.style.display = 'none'; days.style.display = 'none'; }
 
 	</script>
 

--- a/views/partials/day.hbs
+++ b/views/partials/day.hbs
@@ -1,7 +1,28 @@
 <ul>
     <li>
-        <input type="checkbox" id="{{this._id}}">
+        <form action="/schedule", method="POST">
+        <input type="checkbox" id="{{this._id}}" name="_id" value="{{this._id}}">
         <label for="{{this._id}}">
         {{title}} - {{description}}
+        </form>
+
     </li>
 </ul>
+
+<script>
+//submits the form and sends the id of the checkbox to the POST route
+window.onload = function () {
+	var checkboxes = document.querySelectorAll('input[type="checkbox"]');
+
+	checkboxes.forEach((checkbox) => {
+		checkbox.addEventListener('change', function () {
+			if (this.checked) {
+				console.log(this.id);
+				const form = checkbox.closest('form');
+				form.submit();
+			}
+		});
+	});
+};
+
+</script>


### PR DESCRIPTION
Accidentally comitted too early. This PR includes:
- Moving the hide/unhide functionality from the script.js to its specific view (the console complained about not finding elements cause they aren't loaded if the user is not on the create-task-page)
- Adding the functionality to submit the ID of an activity in the View Schedule section to the View Schedule POST route just by checking the box
- Creating the POST route itself
- Updating the specific activity's "isDone" property to true, thus marking the activity done