### PR TITLE
Fix view schedule shows this weeks and next weeks activity

### DIFF
--- a/routes/activity.routes.js
+++ b/routes/activity.routes.js
@@ -139,7 +139,7 @@ router.get('/schedule', async (req, res, next) => {
 	const userId = req.session.currentUser._id;
 	const currentDate = new Date(new Date().setHours(1, 0, 0, 0));
 	const nextWeek = new Date();
-	nextWeek.setDate(currentDate.getDate() + 7);
+	nextWeek.setDate(currentDate.getDate() + 6);
 
 	// Get the current date
 	const now = new Date();

--- a/views/schedule.hbs
+++ b/views/schedule.hbs
@@ -15,14 +15,7 @@
 </div>
 
 
-<div class="row border rounded m-4 p-2">
-    <h4>Sunday</h4>
-    {{#each activities}}
-        {{#if hasSunday}}
-            {{> day}}
-        {{/if}}
-    {{/each}}
-</div>
+
 
 <div class="row border rounded m-4 p-2">
     <h4>Monday</h4>
@@ -73,6 +66,15 @@
     <h4>Saturday</h4>
     {{#each activities}}
         {{#if hasSaturday}}
+            {{> day}}
+        {{/if}}
+    {{/each}}
+</div>
+
+<div class="row border rounded m-4 p-2">
+    <h4>Sunday</h4>
+    {{#each activities}}
+        {{#if hasSunday}}
             {{> day}}
         {{/if}}
     {{/each}}


### PR DESCRIPTION
Because the logic in the backend said to show all activities with a date >= today and <= today + 7, the View Schedule page showed a recurring activity for today (the 13th) as well as for next week (13+ 7 the 20th). Because the activity is named the same it seems like a duplicate activitiy. This PR:

- changes the logic to date >= today and <= today + 6
- moves Sunday all the way to the bottom again in the View, since it wont show the Sunday that is one less than today's date but the one that is 6 days out. Which does not make sense to display it in the list before today's Monday.

Hope you followed that!