### PR TITLE
Remove requirement for the groupID

### DIFF
--- a/models/Activity.model.js
+++ b/models/Activity.model.js
@@ -12,7 +12,6 @@ const activitySchema = new Schema(
 		},
 		description: {
 			type: String,
-			required: true,
 		},
 		category: {
 			type: String,
@@ -41,8 +40,7 @@ const activitySchema = new Schema(
 			},
 		},
 		groupId: {
-			type: String,
-			required: true,
+			type: String ,
 			default: ''
 		}
 	},


### PR DESCRIPTION
The groupID is automatically created for weekly activities, but not for One Time events.
The requirement in the Model threw an error upon single activity creation, so I removed it.