### PR TITLE
Disable menu buttons dynamically

### DIFF
--- a/views/create-activity.hbs
+++ b/views/create-activity.hbs
@@ -1,159 +1,139 @@
-<div class="row justify-content-center">
-  <div class="col-xxl-8 col-xl-8 col-lg-10 col-12 my-3">
-    <h2>Add a new task</h2>
+<div class='row justify-content-center'>
+	<div class='col-xxl-8 col-xl-8 col-lg-10 col-12 my-3'>
+		<h2>Add a new task</h2>
 
-    {{! Add a title }}
-    <form action="/create" method="POST">
-      <div class="row justify-content-center">
-        <div class="col-12 my-1">
-          <label for="title">Title</label>
-        </div>
-      </div>
-      <div class="row justify-content-center">
-        <div class="col-12 my-1">
-          <input
-            type="text"
-            id="title"
-            class="form-control"
-            name="title"
-            required
-          />
-        </div>
-      </div>
+		{{! Add a title }}
+		<form action='/create' method='POST'>
+			<div class='row justify-content-center'>
+				<div class='col-12 my-1'>
+					<label for='title'>Title</label>
+				</div>
+			</div>
+			<div class='row justify-content-center'>
+				<div class='col-12 my-1'>
+					<input type='text' id='title' class='form-control' name='title' required />
+				</div>
+			</div>
 
-      {{! Add a description }}
-      <div class="row justify-content-center">
-        <div class="col-12 my-1">
-          <label for="description">Description</label>
-        </div>
-      </div>
+			{{! Add a description }}
+			<div class='row justify-content-center'>
+				<div class='col-12 my-1'>
+					<label for='description'>Description</label>
+				</div>
+			</div>
 
-      <div class="row justify-content-center">
-        <div class="col-12 my-1">
-          <textarea
-            id="description"
-            class="form-control"
-            name="description"
-            required
-          ></textarea>
-        </div>
-      </div>
+			<div class='row justify-content-center'>
+				<div class='col-12 my-1'>
+					<textarea
+						id='description'
+						class='form-control'
+						name='description'
+						required
+					></textarea>
+				</div>
+			</div>
 
-      {{! Select whether the task is to be added once or recurringly }}
-      <div class="row justify-content-center">
-        <div class="col-12 my-1">
-          <label for="repeat">Repeat</label>
-        </div>
-      </div>
+			{{! Select whether the task is to be added once or recurringly }}
+			<div class='row justify-content-center'>
+				<div class='col-12 my-1'>
+					<label for='repeat'>Repeat</label>
+				</div>
+			</div>
 
-      <div class="row justify-content-center">
-        <div class="col-12 my-1">
-          <select id="repeat" name="repeat" oninput="selectRecurrence()">
-            <option disabled selected> -- select an option -- </option>
-            <option value="once">Once</option>
-            <option value="weekly">Weekly</option>
-          </select>
-        </div>
-      </div>
+			<div class='row justify-content-center'>
+				<div class='col-12 my-1'>
+					<select id='repeat' name='repeat' oninput='selectRecurrence()'>
+						<option disabled selected> -- select an option -- </option>
+						<option value='once'>Once</option>
+						<option value='weekly'>Weekly</option>
+					</select>
+				</div>
+			</div>
 
-      {{! This block only shows when "once" was selected }}
-      <div id="specific-day" class="row justify-content-center">
-        <div class="row justify-content-center">
-          <div class="col-12 my-1">
-            <label for="specificDate">Choose a date</label>
-          </div>
-        </div>
+			{{! This block only shows when "once" was selected }}
+			<div id='specific-day' class='row justify-content-center'>
+				<div class='row justify-content-center'>
+					<div class='col-12 my-1'>
+						<label for='specificDate'>Choose a date</label>
+					</div>
+				</div>
 
-        <div class="row justify-content-center">
-          <div class="col-12 my-1">
-            <input type="date" id="specificDate" name="specificDate" />
-          </div>
-        </div>
+				<div class='row justify-content-center'>
+					<div class='col-12 my-1'>
+						<input type='date' id='specificDate' name='specificDate' />
+					</div>
+				</div>
 
-        <div class="row justify-content-center">
-          <div class="col-12 my-4">
-            <input type="submit" value="Add Task" class="btn btn-primary" />
-          </div>
-        </div>
-      </div>
+				<div class='row justify-content-center'>
+					<div class='col-12 my-4'>
+						<input type='submit' value='Add Task' class='btn btn-primary' />
+					</div>
+				</div>
+			</div>
 
-      {{! This block only shows when "repeat" was selected }}
-      <div id="days" class="row justify-content-center">
-        <div class="col-12 m-1">
-          <label for="daysOfWeek"><p>For which days do you want to add this
-              task?</p></label>
-        </div>
-        <div class="col-12 m-1">
-          <input type="checkbox" id="Sunday" name="daysOfWeek" value="Sunday" />
-          <label for="Sunday">Sunday</label>
-        </div>
+			{{! This block only shows when "repeat" was selected }}
+			<div id='days' class='row justify-content-center'>
+				<div class='col-12 m-1'>
+					<label for='daysOfWeek'><p>For which days do you want to add this task?</p></label>
+				</div>
+				<div class='col-12 m-1'>
+					<input type='checkbox' id='Sunday' name='daysOfWeek' value='Sunday' />
+					<label for='Sunday'>Sunday</label>
+				</div>
 
-        <div class="col-12 m-1">
-          <input type="checkbox" id="Monday" name="daysOfWeek" value="Monday" />
-          <label for="Monday">Monday</label>
-        </div>
+				<div class='col-12 m-1'>
+					<input type='checkbox' id='Monday' name='daysOfWeek' value='Monday' />
+					<label for='Monday'>Monday</label>
+				</div>
 
-        <div class="col-12 m-1">
-          <input
-            type="checkbox"
-            id="Tuesday"
-            name="daysOfWeek"
-            value="Tuesday"
-          />
-          <label for="Tuesday">Tuesday</label>
-        </div>
-        <div class="col-12 m-1">
-          <input
-            type="checkbox"
-            id="Wednesday"
-            name="daysOfWeek"
-            value="Wednesday"
-          />
-          <label for="Wednesday">Wednesday</label>
-        </div>
-        <div class="col-12 m-1">
-          <input
-            type="checkbox"
-            id="Thursday"
-            name="daysOfWeek"
-            value="Thursday"
-          />
-          <label for="Thursday">Thursday</label>
-        </div>
-        <div class="col-12 m-1">
-          <input type="checkbox" id="Friday" name="daysOfWeek" value="Friday" />
-          <label for="Friday">Friday</label>
-        </div>
-        <div class="col-12 m-1">
-          <input
-            type="checkbox"
-            id="Saturday"
-            name="daysOfWeek"
-            value="Saturday"
-          />
-          <label for="Saturday">Saturday</label>
-        </div>
+				<div class='col-12 m-1'>
+					<input type='checkbox' id='Tuesday' name='daysOfWeek' value='Tuesday' />
+					<label for='Tuesday'>Tuesday</label>
+				</div>
+				<div class='col-12 m-1'>
+					<input type='checkbox' id='Wednesday' name='daysOfWeek' value='Wednesday' />
+					<label for='Wednesday'>Wednesday</label>
+				</div>
+				<div class='col-12 m-1'>
+					<input type='checkbox' id='Thursday' name='daysOfWeek' value='Thursday' />
+					<label for='Thursday'>Thursday</label>
+				</div>
+				<div class='col-12 m-1'>
+					<input type='checkbox' id='Friday' name='daysOfWeek' value='Friday' />
+					<label for='Friday'>Friday</label>
+				</div>
+				<div class='col-12 m-1'>
+					<input type='checkbox' id='Saturday' name='daysOfWeek' value='Saturday' />
+					<label for='Saturday'>Saturday</label>
+				</div>
 
-        <div class="row justify-content-center">
-          <div class="col-12 my-4">
-            <input
-              type="submit"
-              value="Add recurring task"
-              class="btn btn-primary"
-            />
-          </div>
-        </div>
-      </div>
+				<div class='row justify-content-center'>
+					<div class='col-12 my-4'>
+						<input
+							type='submit'
+							value='Add recurring task'
+							class='btn btn-primary'
+						/>
+					</div>
+				</div>
+			</div>
 
-    </form>
+		</form>
 
-  </div>
+	</div>
 </div>
-{{! Script to toggle display of specific date selection or weekdays }}
+
+{{!-- prettier-ignore --}}
 <script>
-  window.onload = function () { const repeat =
-  document.getElementById('repeat'); const days =
-  document.getElementById('days'); const specificDay =
-  document.getElementById('specific-day'); specificDay.style.display = 'none';
-  days.style.display = 'none'; }
+  window.onload = function () {
+    const repeat = document.getElementById('repeat');
+    const days = document.getElementById('days');
+    const specificDay = document.getElementById('specific-day');
+      specificDay.style.display = 'none';
+      days.style.display = 'none';
+
+  const createButton = document.querySelector('.create-button');
+        createButton.setAttribute('href', '#')
+
+  }
 </script>

--- a/views/home.hbs
+++ b/views/home.hbs
@@ -29,3 +29,12 @@
 		{{> randomfact}}
 
 </div>
+
+<script>
+
+window.onload = function() {
+  const homeButton = document.querySelector('.home-button');
+  homeButton.setAttribute('href', '#')
+};
+
+</script>

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -1,127 +1,127 @@
-<html lang="en">
+<html lang='en'>
 
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <title>{{appTitle}}</title>
-    <!-- Bootstrap -->
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
-      crossorigin="anonymous"
-    />
-    <!-- Stylesheet -->
-    <link rel="stylesheet" href="/stylesheets/style.css" />
-  </head>
-  <body>
+	<head>
+		<meta charset='UTF-8' />
+		<meta name='viewport' content='width=device-width, initial-scale=1.0' />
+		<meta http-equiv='X-UA-Compatible' content='ie=edge' />
+		<title>{{appTitle}}</title>
+		<!-- Bootstrap -->
+		<link
+			href='https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css'
+			rel='stylesheet'
+			integrity='sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC'
+			crossorigin='anonymous'
+		/>
+		<!-- Stylesheet -->
+		<link rel='stylesheet' href='/stylesheets/style.css' />
+	</head>
+	<body>
 
-    {{#if loggedOut}}
-      <!-- Logged out HEADER w/o navigation -->
+		{{#if loggedOut}}
+			<!-- Logged out HEADER w/o navigation -->
 
-      <nav
-        id="top-nav"
-        class="navbar row justify-content-center fixed-top navbar-expand-md navbar-light bg-white"
-      >
-        <div id="logo" class="col-xxl-6 col-xl-8 col-lg-10 col-md-10">
-          <h1><a href="/" id="logo" class="navbar-brand">logo</a></h1>
-        </div>
-      </nav>
+			<nav
+				id='top-nav'
+				class='navbar row justify-content-center fixed-top navbar-expand-md navbar-light bg-white'
+			>
+				<div id='logo' class='col-xxl-6 col-xl-8 col-lg-10 col-md-10'>
+					<h1><a href='/' id='logo' class='navbar-brand'>logo</a></h1>
+				</div>
+			</nav>
 
-      <main id="main" class="container">
-        {{{body}}}
-      </main>
-      <!-- Logged out FOOTER w/ credits -->
-      <footer
-        id="bottom-nav"
-        class="navbar fixed-bottom navbar-dark bg-dark justify-content-center text-light"
-      >
-        Developed by Johannes, Lukas and Nana
-      </footer>
+			<main id='main' class='container'>
+				{{{body}}}
+			</main>
+			<!-- Logged out FOOTER w/ credits -->
+			<footer
+				id='bottom-nav'
+				class='navbar fixed-bottom navbar-dark bg-dark justify-content-center text-light'
+			>
+				Developed by Johannes, Lukas and Nana
+			</footer>
 
-    {{else}}
-      <!-- Logged in HEADER w/ navigation -->
+		{{else}}
+			<!-- Logged in HEADER w/ navigation -->
 
-      <nav
-        id="top-nav"
-        class="navbar row justify-content-center fixed-top navbar-expand-md navbar-light bg-white fixed-top"
-      >
-        <div class="container-fluid col-xxl-6 col-xl-8 col-lg-10 col-md-10">
-          <a href="/" id="logo" class="navbar-brand">logo</a>
-          <button
-            class="navbar-toggler"
-            type="button"
-            data-bs-toggle="collapse"
-            data-bs-target="#toggleMobileMenu"
-            aria-controls="toggleMobileMenu"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-          >
-            <span class="navbar-toggler-icon"></span>
-          </button>
-          <div class="collapse navbar-collapse ms-auto" id="toggleMobileMenu">
-            <ul class="navbar-nav ms-auto text-center">
-              <li class="nav-item">
-                <a
-                  href="/profile"
-                  id="menu-button"
-                  class="nav-link btn"
-                >Profile</a>
-              </li>
-              <li class="nav-item">
-                <form action="/logout" method="POST">
-                  <input
-                    type="submit"
-                    value="Log Out"
-                    id="menu-button"
-                    class="nav-link btn"
-                  />
-                </form>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </nav>
-      <main id="main" class="container-md">
-        {{{body}}}
-      </main>
+			<nav
+				id='top-nav'
+				class='navbar row justify-content-center fixed-top navbar-expand-md navbar-light bg-white fixed-top'
+			>
+				<div class='container-fluid col-xxl-6 col-xl-8 col-lg-10 col-md-10'>
+					<a href='/' id='logo' class='navbar-brand'>logo</a>
+					<button
+						class='navbar-toggler'
+						type='button'
+						data-bs-toggle='collapse'
+						data-bs-target='#toggleMobileMenu'
+						aria-controls='toggleMobileMenu'
+						aria-expanded='false'
+						aria-label='Toggle navigation'
+					>
+						<span class='navbar-toggler-icon'></span>
+					</button>
+					<div class='collapse navbar-collapse ms-auto' id='toggleMobileMenu'>
+						<ul class='navbar-nav ms-auto text-center'>
+							<li class='nav-item'>
+								<a
+									href='/profile'
+									id='menu-button'
+									class='nav-link btn'
+								>Profile</a>
+							</li>
+							<li class='nav-item'>
+								<form action='/logout' method='POST'>
+									<input
+										type='submit'
+										value='Log Out'
+										id='menu-button'
+										class='nav-link btn'
+									/>
+								</form>
+							</li>
+						</ul>
+					</div>
+				</div>
+			</nav>
+			<main id='main' class='container-md'>
+				{{{body}}}
+			</main>
 
-      <!-- Logged in FOOTER w/ navigation -->
-      <nav
-        id="bottom-nav"
-        class="navbar row row-cols-3 fixed-bottom navbar-dark bg-dark justify-content-center"
-      >
+			<!-- Logged in FOOTER w/ navigation -->
+			<nav
+				id='bottom-nav'
+				class='navbar row row-cols-3 fixed-bottom navbar-dark bg-dark justify-content-center'
+			>
 
-        <div class="nav-item col-md-2 col-sm-1 text-center">
-          <a href="/home" id="menu-button" class="btn btn-primary">
-            <div><i class="bi bi-house"></i></div>
-            <div class="pt-1">Home</div>
-          </a>
-        </div>
-        <div class="nav-item col-md-2 col-sm-1 text-center">
-          <a href="/schedule" id="menu-button" class="btn btn-primary">
-            <div><i class="bi bi-calendar-week"></i></div>
-            <div class="pt-1">Schedule</div>
-          </a>
-        </div>
-        <div class="nav-item col-md-2 col-sm-1 text-center">
-          <a href="/create" id="menu-button" class="btn btn-primary">
-            <div><i class="bi bi-plus-square"></i></div>
-            <div class="pt-1">Add Task</div>
-          </a>
-        </div>
+				<div class='nav-item col-md-2 col-sm-1 text-center'>
+					<a href='/home' id='menu-button' class='btn btn-primary home-button'>
+						<div><i class='bi bi-house'></i></div>
+						<div class='pt-1'>Home</div>
+					</a>
+				</div>
+				<div class='nav-item col-md-2 col-sm-1 text-center'>
+					<a href='/schedule' id='menu-button' class='btn btn-primary schedule-button'>
+						<div><i class='bi bi-calendar-week'></i></div>
+						<div class='pt-1'>Schedule</div>
+					</a>
+				</div>
+				<div class='nav-item col-md-2 col-sm-1 text-center'>
+					<a href='/create' id='menu-button' class='btn btn-primary create-button'>
+						<div><i class='bi bi-plus-square'></i></div>
+						<div class='pt-1'>Add Task</div>
+					</a>
+				</div>
 
-      </nav>
-    {{/if}}
+			</nav>
+		{{/if}}
 
-    <script src="/js/script.js"></script>
-    <!-- Bootstrap -->
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
-      crossorigin="anonymous"
-    ></script>
-  </body>
+		<script src='/js/script.js'></script>
+		<!-- Bootstrap -->
+		<script
+			src='https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js'
+			integrity='sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM'
+			crossorigin='anonymous'
+		></script>
+	</body>
 
 </html>

--- a/views/schedule.hbs
+++ b/views/schedule.hbs
@@ -90,3 +90,12 @@
 	{{> randomfact}}
     </div>
 </div>
+
+<script>
+
+window.onload = function() {
+  const scheduleButton = document.querySelector('.schedule-button');
+  scheduleButton.setAttribute('href', '#')
+};
+
+</script>


### PR DESCRIPTION
I added script-tags in every view for create, view schedule and home that updates the href-source of the corresponding button on the layout.hbs.

Meaning: in layout.hbs are the buttons for /home, /create and /schedule. I gave them each an additional class called either "home-button" etc. In the specific view (like home.hbs) I selected the corresponding link (view querySelector('.home-button') and gave its "href" a new property. Instead of "href:/home" it will now say "href:#" as soon as the home page is loaded. 

The buttons will not work until you switch pages.