### PR TITLE
Add "postpone one day" button to week view

### DIFF
--- a/routes/activity.routes.js
+++ b/routes/activity.routes.js
@@ -274,10 +274,11 @@ router.get('/schedule', async (req, res, next) => {
 			},
 		});
 
+
 		// Filter the activities to only include those within the coming week
 		const comingWeekActivities = activities.filter((activity) => {
 			const activityDate = new Date(activity.specificDate);
-			return activityDate >= currentDate && activityDate < nextWeek;
+			return activityDate >= currentDate && activityDate <= nextWeek;
 		});
 
 		let noMonday = true;
@@ -376,11 +377,28 @@ router.get('/schedule', async (req, res, next) => {
 });
 
 router.post('/schedule', isLoggedIn, async (req, res, next) => {
-	const { _id } = req.body;
+	const { _id , update, specificDate } = req.body;
+	console.log(req.body);
+
+
+
 
 	try {
-		const activity = await Activity.findByIdAndUpdate(_id, { isDone: true }, { new: true });
-		console.log(activity);
+
+		if (update === '+') {
+
+			let date = new Date(specificDate);
+			date.setDate(date.getDate() + 1);
+
+			const activity= await Activity.findByIdAndUpdate(_id, { specificDate: date }, { new: true });
+			console.log(activity);
+
+		} else {const activity = await Activity.findByIdAndUpdate(_id, { isDone: true }, { new: true });
+		console.log(activity);}
+
+
+
+
 	} catch (error) {
 		console.error(error);
 		next(error);

--- a/views/partials/day.hbs
+++ b/views/partials/day.hbs
@@ -1,52 +1,40 @@
 {{#if this.isDone}}
-  <div class="row row-cols-auto">
-    <form class="col-xxl-8 col-xl-8 col-lg-10 col-md-10 my-3">
-      <div class="col-10 text-success">
-        <input
-          type="checkbox"
-          id="{{this._id}}"
-          name="_id"
-          value="{{this._id}}"
-          checked
-        />
-        <label id="{{this._id}}" for="{{this._id}}">
-          <a href="/schedule/{{this._id}}">{{title}}</a>
-        </label>
-        –
-        {{description}}
+	<div class='row row-cols-auto'>
+		<form class='col-xxl-8 col-xl-8 col-lg-10 col-md-10 my-3'>
+			<div class='col-10 text-success'>
+				<input type='checkbox' id='{{this._id}}' name='_id' value='{{this._id}}' checked />
+				<label id='{{this._id}}' for='{{this._id}}'>
+					<a href='/schedule/{{this._id}}'>{{title}}</a>
+				</label>
+				–
+				{{description}}
 
-      </div>
-    </form>
-  </div>
+			</div>
+		</form>
+	</div>
 
 {{else}}
-  <div class="row row-cols-auto">
+	<div class='row row-cols-auto'>
 
-    <form
-      class="col-xxl-8 col-xl-8 col-lg-10 col-md-10"
-      action="/schedule"
-      method="POST"
-    >
-      <div class="col-xxl-8 col-xl-8 col-lg-10 col-md-10">
-        <input
-          type="checkbox"
-          id="{{this._id}}"
-          name="_id"
-          value="{{this._id}}"
-        />
-        <label id="{{this._id}}" for="{{this._id}}">
-          <a
-            href="/schedule/{{this._id}}"
-            class="font-weight-bold"
-          >{{title}}</a>
-        </label>
-        –
-        {{description}}
+		<form class='col-xxl-8 col-xl-8 col-lg-10 col-md-10' action='/schedule' method='POST'>
+			<div class='col-xxl-8 col-xl-8 col-lg-10 col-md-10'>
+				<input type='checkbox' id='{{this._id}}' name='_id' value='{{this._id}}' />
+				<label id='{{this._id}}' for='{{this._id}}'>
+					<a href='/schedule/{{this._id}}' class='font-weight-bold'>{{title}}</a>
+				</label>
+				–
+				{{description}}
 
-      </div>
+			</div>
 
-    </form>
-  </div>
+		</form>
+
+		<form action='/schedule' method='POST'>
+			<input type='hidden' name='_id' value='{{this._id}}' />
+			<input type='hidden' name='specificDate' value='{{this.specificDate}}' />
+			<input type='submit' id='{{this._id}}' name='update' value='+' />
+		</form>
+	</div>
 
 {{/if}}
 
@@ -66,6 +54,8 @@
 				}
 			});
 		});
+
+
 	};
 
 </script>

--- a/views/schedule.hbs
+++ b/views/schedule.hbs
@@ -120,11 +120,11 @@
     </div>
 </div>
 
-<script>
+{{!-- <script>
 
 window.onload = function() {
   const scheduleButton = document.querySelector('.schedule-button');
   scheduleButton.setAttribute('href', '#')
 };
 
-</script>
+</script> --}}


### PR DESCRIPTION
This PR does a bunch of things:
- Add a submit-button to the day-partial which will add one day to the specific DAte of an activity, thus postponing it (on my browser it didn't automatically refresh the window, it'd be cool if it did though)
- I took out the dynamic disabling of the View Schedule menu button, because if it is disabled, apparently the window.onload functions to submit an "isDone" value upon checkbox click doesn'T work anymore. This way you can just refresh the week view at all times, which is not too bad I guess.
- I fixed a heretofore not known (by me at least) problem that activities for the last day of the week (sunday in our case) would not be shown because the equation excludes all activities EQUAL to the end-weeks date. I set it to Less Or Equal.