### PR TITLE
Edit details route for two use cases

### DIFF
--- a/routes/activity.routes.js
+++ b/routes/activity.routes.js
@@ -409,6 +409,8 @@ router.post('/schedule/:id', isLoggedIn, async (req, res, next) => {
 	try {
 		const updateActivity = await Activity.findById(id);
 
+		if (specificDate) {
+
 		if (update === 'Edit One') {
 			await Activity.findByIdAndUpdate(
 				id,
@@ -437,8 +439,24 @@ router.post('/schedule/:id', isLoggedIn, async (req, res, next) => {
 		else {
 			return res.status(404).send('Activity not found');
 		}
-
 		res.redirect('/schedule');
+	}
+		else {
+			if (update === 'Edit One') {
+				await Activity.findByIdAndUpdate(
+					id,
+					{ title, description, category, daysOfWeek, repeat },
+					{ new: true }
+				);
+			} else if (update === 'Edit All') {
+				await Activity.updateMany(
+					{ groupId: updateActivity.groupId },
+					{ title, description, category, daysOfWeek, repeat },
+					{ new: true }
+				);
+			}
+
+		res.redirect('/schedule');}
 	} catch (error) {
 		next(error);
 	}

--- a/views/edit-activity.hbs
+++ b/views/edit-activity.hbs
@@ -14,7 +14,6 @@
 		type='date'
 		id='date'
 		name='specificDate'
-		required
 		pattern='\d{4}-\d{2}-\d{2}'
 		value='{{findActivity.specificDate}}'
 	/>


### PR DESCRIPTION
If user didn't want to change the date for a task in the Edit view, it saved the updated task with date "null" and thus the tasks disappeared.

This PR adds:
- an if-condition on wether a new specificDate was input by the user - if not, the original date will be preserved
- delete the requirement for putting in a date in the edit form (something I thought helped submit the date in the correct order but was unrelated)