### PR TITLE
Keep current category if it's not edited

### DIFF
--- a/views/edit-activity.hbs
+++ b/views/edit-activity.hbs
@@ -20,13 +20,15 @@
 
 	<br />
 	<label for='category'>Category</label>
-		<select id='category' name='category'>
-			<option value='Sports' selected>Sports</option>
-			<option value='Studying' selected>Studying</option>
-			<option value='Work' selected>Work</option>
-			<option value='Social Life'selected>Social Life</option>
-			<option value='Other'selected>Other</option>
-		</select>
+	<select id='category' name='category'>
+		<option value='Sports'>Sports</option>
+		<option value='Studying'>Studying</option>
+		<option value='Work'>Work</option>
+		<option value='Social Life'>Social Life</option>
+		<option value='Other'>Other</option>
+		<option hidden value='{{findActivity.category}}' selected>{{findActivity.category}}</option>
+
+	</select>
 	<br />
 	<input type='submit' value='Edit One' name='update' />
 	<br />


### PR DESCRIPTION
In the edit activity view, the Category changed with every edit even when it wasn't the property the user wanted to edit.
Now the edit view Category defaults to the Category saved in the activity and has to be specifically changed if that's what the user wants.